### PR TITLE
Fix pin input over-aligning to the right especially in mobile

### DIFF
--- a/resources/less/desktop.less
+++ b/resources/less/desktop.less
@@ -379,10 +379,10 @@ a {
 
     .wizard-step-content {
       background-color: #ebf0f2;
-      width: 125%;
+      width: 100%;
       text-align: center!important;
       padding: (7px - 3.5px) 0 7px;
-      margin: 5px 0 5px @widget-padding-left-base * -1;
+      margin: 5px 0 5px 0;
       .box-sizing(border-box);
 
       & > div {

--- a/resources/views/verification/step/code.html
+++ b/resources/views/verification/step/code.html
@@ -4,7 +4,7 @@
         <h3 class="phone-number"></h3>
       </div>
       <div class="wizard-step-content">
-        <div style="text-align:center;">
+        <div style="text-align:center;width:100%">
           <p class="pin-summary"><%= i18n.trans('check.summary') %></p>
           <input type="tel" class="form-control digit" autocomplete="off" maxlength="1">&nbsp;
           <input type="tel" class="form-control digit" autocomplete="off" maxlength="1">&nbsp;


### PR DESCRIPTION
Add style to center pin input that works on desktop, mobile, etc.